### PR TITLE
feat(core): add stepper component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35913,10 +35913,10 @@
     },
     "packages/core-components": {
       "name": "@otto-de/b2b-core-components",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@otto-de/b2b-tokens": "1.0.1",
+        "@otto-de/b2b-tokens": "1.1.0",
         "@stencil-community/eslint-plugin": "^0.5.0",
         "@stencil/core": "^3.0.1"
       },
@@ -35977,10 +35977,10 @@
     },
     "packages/react-components": {
       "name": "@otto-de/b2b-react-components",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@otto-de/b2b-core-components": "1.0.1"
+        "@otto-de/b2b-core-components": "1.1.0"
       },
       "devDependencies": {
         "@types/node": "^18.16.0",
@@ -35991,7 +35991,7 @@
     },
     "packages/tokens": {
       "name": "@otto-de/b2b-tokens",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "lodash": "^4.17.21",
@@ -38928,7 +38928,7 @@
       "requires": {
         "@babel/core": "^7.21.3",
         "@fullhuman/postcss-purgecss": "^5.0.0",
-        "@otto-de/b2b-tokens": "1.0.1",
+        "@otto-de/b2b-tokens": "1.1.0",
         "@stencil-community/eslint-plugin": "^0.5.0",
         "@stencil/core": "^3.0.1",
         "@stencil/postcss": "^2.1.0",
@@ -38981,7 +38981,7 @@
     "@otto-de/b2b-react-components": {
       "version": "file:packages/react-components",
       "requires": {
-        "@otto-de/b2b-core-components": "1.0.1",
+        "@otto-de/b2b-core-components": "1.1.0",
         "@types/node": "^18.16.0",
         "@types/react": "^17.0.58",
         "@types/react-dom": "^17.0.19",
@@ -47942,6 +47942,11 @@
             "trim-newlines": "3.0.1",
             "type-fest": "^0.18.0",
             "yargs-parser": "^20.2.3"
+          },
+          "dependencies": {
+            "trim-newlines": {
+              "version": "3.0.1"
+            }
           }
         },
         "type-fest": {
@@ -47993,6 +47998,11 @@
             "trim-newlines": "3.0.1",
             "type-fest": "^0.18.0",
             "yargs-parser": "^20.2.3"
+          },
+          "dependencies": {
+            "trim-newlines": {
+              "version": "3.0.1"
+            }
           }
         },
         "type-fest": {
@@ -48839,6 +48849,11 @@
             "read-pkg-up": "^1.0.1",
             "redent": "^1.0.0",
             "trim-newlines": "3.0.1"
+          },
+          "dependencies": {
+            "trim-newlines": {
+              "version": "3.0.1"
+            }
           }
         },
         "normalize-package-data": {
@@ -51220,6 +51235,11 @@
             "trim-newlines": "3.0.1",
             "type-fest": "^0.18.0",
             "yargs-parser": "^20.2.3"
+          },
+          "dependencies": {
+            "trim-newlines": {
+              "version": "3.0.1"
+            }
           }
         },
         "type-fest": {
@@ -54859,6 +54879,9 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
           "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
           "dev": true
+        },
+        "trim-newlines": {
+          "version": "3.0.1"
         }
       }
     },
@@ -55530,6 +55553,11 @@
         "sass-graph": "4.0.1",
         "stdout-stream": "^1.4.0",
         "true-case-path": "^1.0.2"
+      },
+      "dependencies": {
+        "sass-graph": {
+          "version": "4.0.1"
+        }
       }
     },
     "noms": {
@@ -59561,6 +59589,11 @@
         "unist-util-remove-position": "^2.0.0",
         "vfile-location": "^3.0.0",
         "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "trim": {
+          "version": "0.0.3"
+        }
       }
     },
     "remark-slug": {

--- a/packages/core-components/src/components.d.ts
+++ b/packages/core-components/src/components.d.ts
@@ -584,6 +584,10 @@ export namespace Components {
          */
         "size": '50' | '100' | '200';
     }
+    interface B2bStepper {
+        "stepIndex": number;
+        "steps": string[];
+    }
     interface B2bTab {
         /**
           * Whether or not the tab is currently disabled. Per default it is false.
@@ -1039,6 +1043,12 @@ declare global {
         prototype: HTMLB2bSpinnerElement;
         new (): HTMLB2bSpinnerElement;
     };
+    interface HTMLB2bStepperElement extends Components.B2bStepper, HTMLStencilElement {
+    }
+    var HTMLB2bStepperElement: {
+        prototype: HTMLB2bStepperElement;
+        new (): HTMLB2bStepperElement;
+    };
     interface HTMLB2bTabElement extends Components.B2bTab, HTMLStencilElement {
     }
     var HTMLB2bTabElement: {
@@ -1147,6 +1157,7 @@ declare global {
         "b2b-search": HTMLB2bSearchElement;
         "b2b-separator": HTMLB2bSeparatorElement;
         "b2b-spinner": HTMLB2bSpinnerElement;
+        "b2b-stepper": HTMLB2bStepperElement;
         "b2b-tab": HTMLB2bTabElement;
         "b2b-tab-group": HTMLB2bTabGroupElement;
         "b2b-tab-panel": HTMLB2bTabPanelElement;
@@ -1795,6 +1806,10 @@ declare namespace LocalJSX {
          */
         "size"?: '50' | '100' | '200';
     }
+    interface B2bStepper {
+        "stepIndex"?: number;
+        "steps"?: string[];
+    }
     interface B2bTab {
         /**
           * Whether or not the tab is currently disabled. Per default it is false.
@@ -2054,6 +2069,7 @@ declare namespace LocalJSX {
         "b2b-search": B2bSearch;
         "b2b-separator": B2bSeparator;
         "b2b-spinner": B2bSpinner;
+        "b2b-stepper": B2bStepper;
         "b2b-tab": B2bTab;
         "b2b-tab-group": B2bTabGroup;
         "b2b-tab-panel": B2bTabPanel;
@@ -2119,6 +2135,7 @@ declare module "@stencil/core" {
              * Initial story: https://otto-eg.atlassian.net/browse/B2BDS-70
              */
             "b2b-spinner": LocalJSX.B2bSpinner & JSXBase.HTMLAttributes<HTMLB2bSpinnerElement>;
+            "b2b-stepper": LocalJSX.B2bStepper & JSXBase.HTMLAttributes<HTMLB2bStepperElement>;
             "b2b-tab": LocalJSX.B2bTab & JSXBase.HTMLAttributes<HTMLB2bTabElement>;
             "b2b-tab-group": LocalJSX.B2bTabGroup & JSXBase.HTMLAttributes<HTMLB2bTabGroupElement>;
             "b2b-tab-panel": LocalJSX.B2bTabPanel & JSXBase.HTMLAttributes<HTMLB2bTabPanelElement>;

--- a/packages/core-components/src/components/stepper/readme.md
+++ b/packages/core-components/src/components/stepper/readme.md
@@ -1,0 +1,18 @@
+# b2b-stepper
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property    | Attribute    | Description | Type       | Default             |
+| ----------- | ------------ | ----------- | ---------- | ------------------- |
+| `stepIndex` | `step-index` |             | `number`   | `1`                 |
+| `steps`     | --           |             | `string[]` | `["test", "test2"]` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/core-components/src/components/stepper/stepper.docs.mdx
+++ b/packages/core-components/src/components/stepper/stepper.docs.mdx
@@ -1,0 +1,41 @@
+import {
+  Story,
+  ArgsTable,
+  PRIMARY_STORY,
+  Primary,
+  Source,
+  Canvas,
+} from '@storybook/addon-docs';
+import dedent from 'ts-dedent';
+
+# Stepper Component
+
+<Canvas columns={3} withSource="open" withToolbar={false}>
+  <Story id="components-interaction-stepper--story-010-stepper" />
+</Canvas>
+
+The stepper component will provide an element that will let you set the current step while navigating.
+
+<br />
+
+## Properties
+
+### steps
+
+Property to provide names of the steps as an simple list of strings
+
+### stepIndex
+
+Property to highlight the current step
+
+<br />
+
+#### Vue
+
+<Source
+  language="tsx"
+  format={false}
+  code={dedent`
+    <b2b-stepper :steps="['Step1', 'Step2']" :stepIndex="1"></b2b-stepper>
+  `}
+/>

--- a/packages/core-components/src/components/stepper/stepper.e2e.tsx
+++ b/packages/core-components/src/components/stepper/stepper.e2e.tsx
@@ -1,0 +1,14 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('B2B-Stepper', () => {
+  let page;
+  beforeEach(async () => {
+    page = await newE2EPage();
+    await page.setContent(`<b2b-stepper></b2b-stepper>`);
+  });
+
+  it('should render stepper component', async () => {
+    const element = await page.find('b2b-stepper');
+    expect(element).not.toBeNull;
+  });
+});

--- a/packages/core-components/src/components/stepper/stepper.scss
+++ b/packages/core-components/src/components/stepper/stepper.scss
@@ -1,0 +1,71 @@
+.b2b_wizard {
+  display: flex;
+  list-style: none;
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  counter-reset: num;
+}
+
+.b2b_wizard__step {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  flex: 1;
+  margin: 0;
+  padding: 0;
+  font-size: 16px;
+  line-height: 24px;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  line-height: 1.25em;
+  color: #c4c4c4;
+}
+
+.b2b_wizard__step:before {
+  counter-increment: num;
+  content: counter(num);
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 2rem;
+  height: 2rem;
+  margin-right: calc(0.75rem / 2);
+  border: 1px solid #c4c4c4;
+  border-radius: 50%;
+}
+
+.b2b_wizard__step--active {
+  color: #222;
+}
+
+.b2b_wizard__step--active:before {
+  color: #fff;
+  border: none;
+  background-color: #d4021d;
+}
+
+.b2b_wizard__step--complete {
+  color: #222;
+}
+
+.b2b_wizard__step--complete:before {
+  color: #fff;
+  border: none;
+  background-color: #326400;
+}
+
+.b2b_wizard__step:last-of-type {
+  flex-grow: 0;
+}
+
+.b2b_wizard__step:not(:last-of-type):after {
+  content: ' ';
+  flex-grow: 1;
+  height: 1px;
+  min-width: 1rem;
+  margin: 0 0.75rem;
+  background: #c4c4c4;
+}

--- a/packages/core-components/src/components/stepper/stepper.spec.tsx
+++ b/packages/core-components/src/components/stepper/stepper.spec.tsx
@@ -1,0 +1,32 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { h } from '@stencil/core';
+import { StepperComponent } from './stepper';
+
+describe('B2B-Stepper', () => {
+  async function renderPage(template) {
+    return newSpecPage({
+      components: [StepperComponent],
+      template: () => template,
+    });
+  }
+
+  it('should render stepper with default attributes', async () => {
+    const page = await renderPage(<b2b-stepper></b2b-stepper>);
+    expect(page.root).toEqualHtml(`
+      <b2b-stepper>
+        <mock:shadow-root>
+        <div class="b2b_grid">
+           <ul class="b2b_wizard">
+              <li class="b2b_wizard__step b2b2_my-4 b2b_wizard__step--complete">
+                <span>test</span>
+              </li>
+              <li class="b2b_wizard__step b2b2_my-4 b2b_wizard__step--active">
+                <span>test2</span>
+              </li>
+            </ul>
+        </div>
+        </mock:shadow-root>
+      </b2b-stepper>
+		`);
+  });
+});

--- a/packages/core-components/src/components/stepper/stepper.stories.tsx
+++ b/packages/core-components/src/components/stepper/stepper.stories.tsx
@@ -1,0 +1,21 @@
+import { Meta, Story } from '@storybook/web-components';
+import { html } from 'lit-html';
+import stepperDocs from './stepper.docs.mdx';
+
+const Template: Story = () => {
+  return html`<b2b-stepper></b2b-stepper>`;
+};
+
+export const story010Stepper = Template.bind({});
+story010Stepper.storyName = 'Default';
+
+export default {
+  title: 'Components/Interaction/Stepper',
+  viewmode: 'docs',
+  parameters: {
+    controls: { expanded: true },
+    docs: {
+      page: stepperDocs,
+    },
+  },
+} as Meta;

--- a/packages/core-components/src/components/stepper/stepper.tsx
+++ b/packages/core-components/src/components/stepper/stepper.tsx
@@ -1,0 +1,38 @@
+import { Component, h, Host, Prop } from '@stencil/core';
+
+@Component({
+  tag: 'b2b-stepper',
+  styleUrl: 'stepper.scss',
+  shadow: true,
+})
+export class StepperComponent {
+  /** The steps to be shown*/
+  @Prop() steps: string[] = ['test', 'test2'];
+  /** The current active step */
+  @Prop() stepIndex: number = 1;
+
+  render() {
+    return (
+      <Host>
+        <div class="b2b_grid">
+          <ul class="b2b_wizard">
+            {this.steps.map((step, index) => {
+              if (this.stepIndex == index)
+                return (
+                  <li class="b2b_wizard__step b2b2_my-4 b2b_wizard__step--active">
+                    <span>{step}</span>
+                  </li>
+                );
+              else
+                return (
+                  <li class="b2b_wizard__step b2b2_my-4 b2b_wizard__step--complete">
+                    <span>{step}</span>
+                  </li>
+                );
+            })}
+          </ul>
+        </div>
+      </Host>
+    );
+  }
+}

--- a/packages/core-components/src/docs/config/components-args.json
+++ b/packages/core-components/src/docs/config/components-args.json
@@ -91,7 +91,7 @@
           "summary": "null"
         }
       },
-      "description": "If set to true, the browser will attempt to donwload and save the URL instead of opening it. The name of the created file\r\ndefaults to the URL string, but can be changed by the user."
+      "description": "If set to true, the browser will attempt to donwload and save the URL instead of opening it. The name of the created file\ndefaults to the URL string, but can be changed by the user."
     },
     "href": {
       "table": {
@@ -177,7 +177,7 @@
         },
         "defaultValue": {}
       },
-      "description": "If set to true, the browser will attempt to donwload and save the URL instead of opening it. The name of the created file\r\ndefaults to the URL string, but can be changed by the user."
+      "description": "If set to true, the browser will attempt to donwload and save the URL instead of opening it. The name of the created file\ndefaults to the URL string, but can be changed by the user."
     },
     "href": {
       "table": {
@@ -1414,7 +1414,7 @@
           "summary": "false"
         }
       },
-      "description": "A boolean that indicates whether the modal can be dismissed by clicking\r\nin the backdrop outside the modal."
+      "description": "A boolean that indicates whether the modal can be dismissed by clicking\nin the backdrop outside the modal."
     },
     "escDismiss": {
       "control": {
@@ -1428,7 +1428,7 @@
           "summary": "true"
         }
       },
-      "description": "A boolean to indicate whether the modal can be dismissed by pressing\r\nthe escape key on the keyboard"
+      "description": "A boolean to indicate whether the modal can be dismissed by pressing\nthe escape key on the keyboard"
     },
     "heading": {
       "table": {
@@ -1883,6 +1883,30 @@
       "description": "The size of the spinner."
     }
   },
+  "b2b-stepper": {
+    "stepIndex": {
+      "table": {
+        "type": {
+          "summary": "number"
+        },
+        "defaultValue": {
+          "summary": "1"
+        }
+      },
+      "description": ""
+    },
+    "steps": {
+      "table": {
+        "type": {
+          "summary": "string[]"
+        },
+        "defaultValue": {
+          "summary": "[\"test\", \"test2\"]"
+        }
+      },
+      "description": ""
+    }
+  },
   "b2b-tab": {
     "disabled": {
       "control": {
@@ -1940,7 +1964,7 @@
           "summary": "false"
         }
       },
-      "description": "Determines if the Tab Group will do it's own navigation. Per default, it will use internal navigation.\r\nSet it to true if you want to use external, route-based navigation."
+      "description": "Determines if the Tab Group will do it's own navigation. Per default, it will use internal navigation.\nSet it to true if you want to use external, route-based navigation."
     }
   },
   "b2b-tab-panel": {},
@@ -1961,7 +1985,7 @@
           "summary": "TableSizes.EXPAND"
         }
       },
-      "description": "The size of the table. Both will expand to 100% of parent size.\r\nExpand cells will use as much space as content needs and text will wrap.\r\nEqual will keep all column sizes proportional to the number of columns."
+      "description": "The size of the table. Both will expand to 100% of parent size.\nExpand cells will use as much space as content needs and text will wrap.\nEqual will keep all column sizes proportional to the number of columns."
     }
   },
   "b2b-table-cell": {
@@ -2033,7 +2057,7 @@
           "summary": "TableSizes.EXPAND"
         }
       },
-      "description": "The size of the cell. Follows table size.\r\nWhen size is equal and textWrap is false, the text will truncate with Ellipsis.\r\nOther sizes won't affect cell current implementation."
+      "description": "The size of the cell. Follows table size.\nWhen size is equal and textWrap is false, the text will truncate with Ellipsis.\nOther sizes won't affect cell current implementation."
     },
     "textWrap": {
       "control": {
@@ -2047,7 +2071,7 @@
           "summary": "true"
         }
       },
-      "description": "Weather text should wrap or truncate.\r\nIt will only truncate when table size is equal\r\n*"
+      "description": "Weather text should wrap or truncate.\nIt will only truncate when table size is equal\n*"
     }
   },
   "b2b-table-header": {
@@ -2159,7 +2183,7 @@
           "summary": "TableRowgroupTypes.HEADER"
         }
       },
-      "description": "Rowgroup allows grouping rows by context: header, body or footer.\r\nHeader rows are by default not highlightable on mouse over."
+      "description": "Rowgroup allows grouping rows by context: header, body or footer.\nHeader rows are by default not highlightable on mouse over."
     }
   },
   "b2b-textarea": {

--- a/packages/core-components/src/docs/guidelines/DEV-GUIDELINES.md
+++ b/packages/core-components/src/docs/guidelines/DEV-GUIDELINES.md
@@ -214,9 +214,19 @@ If the differences where expected run:
 
 To test changes to the docker image that contains the Storybook docs and CDN locally, you'll need to create a production build of Storybook first.
 
+First, create a build of all components in the root folder:
+```shell
+npm run build
+```
+
 In the core-components folder, run:
 ```shell
 npm run build:storybook
+```
+
+Copy the distribution to the storybook build folder:
+```shell
+cp -r dist docs-build/design-system
 ```
 
 Afterwards, you can rebuild the docker image with your changes by running:
@@ -230,13 +240,12 @@ docker run -it -p 80:80 b2bds-docs
 
 Now you can navigate to the following:
 
-| Path name                                                          | Description                                                                                          |
+| Path name | Description |
 |--------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|
-| /design-system                                                     | The Storybook app containing the docs.                                                               |
-| /health                                                            | A simple health check for the ELB in AWS.                                                            |
-| /design-system/dist/b2b-core-components/b2b-core-components.css    | The distribution of our tokens.                                                                      |
+| /design-system                                                     | The Storybook app containing the docs.|
+| /health                                                            | A simple health check for the ELB in AWS.|
+| /design-system/dist/b2b-core-components/b2b-core-components.css    | The distribution of our tokens.|
 | /design-system/dist/b2b-core-components/b2b-core-components.esm.js | The entry file for our components. Additional components will be lazy-loaded on demand by this file. |
-
 
 ## Modifying or creating new tokens
 
@@ -249,3 +258,21 @@ rendering the tokens tables. You can find this stories in `core-components/src/d
 ## ADRs
 
 If you wonder why some tools are in place, you can find our technical decision records in the `ADRs` directory.
+
+## Contribution Checklist
+
+If you are currently or looking to start developing components for the B2B Design System, here's a quick check list to go over when you have finished a story to make sure you're all set to submit a PR:
+
+- [ ] *Component*:
+  - all `@Prop()`, `@Event()` and `@State()`decorators are commented
+  - all `*.tsx` files related to the component have an appropriate component tag that relates to the file name
+- [ ] *Styles*:
+  - all components have a `<component-name>.scss` file associated in the `@Component()` decorator 
+- [ ] *Tests*:
+  - the component has at least an e2e test that covers all relevant interaction as well as edge cases
+  - the component ideally has a snapshot test that shows changes in component structure
+- [ ] *Docs*:
+  - the component has a `<component-name>.stories.tsx` file that contains stories of all relevant states (also for screenshot testing)
+  - the component has a `<component-name>.docs.msx` file that contains usage guidelines and code examples
+- [ ] *Visual Regression Tests*:
+  - the component has screenshot tests for all stories / states

--- a/packages/react-components/src/components/stencil-generated/index.ts
+++ b/packages/react-components/src/components/stencil-generated/index.ts
@@ -35,6 +35,7 @@ export const B2bScrollableContainer = /*@__PURE__*/createReactComponent<JSX.B2bS
 export const B2bSearch = /*@__PURE__*/createReactComponent<JSX.B2bSearch, HTMLB2bSearchElement>('b2b-search');
 export const B2bSeparator = /*@__PURE__*/createReactComponent<JSX.B2bSeparator, HTMLB2bSeparatorElement>('b2b-separator');
 export const B2bSpinner = /*@__PURE__*/createReactComponent<JSX.B2bSpinner, HTMLB2bSpinnerElement>('b2b-spinner');
+export const B2bStepper = /*@__PURE__*/createReactComponent<JSX.B2bStepper, HTMLB2bStepperElement>('b2b-stepper');
 export const B2bTab = /*@__PURE__*/createReactComponent<JSX.B2bTab, HTMLB2bTabElement>('b2b-tab');
 export const B2bTabGroup = /*@__PURE__*/createReactComponent<JSX.B2bTabGroup, HTMLB2bTabGroupElement>('b2b-tab-group');
 export const B2bTabPanel = /*@__PURE__*/createReactComponent<JSX.B2bTabPanel, HTMLB2bTabPanelElement>('b2b-tab-panel');


### PR DESCRIPTION
The old design provided an stepper functionality. We would love such an feature in the this library. 

**Goal**: 
Navigation through a process should be indicated by an **stepper component**

<b2b-stepper></b2b-stepper>

**example props:**
steps = ["Step1", "Step2"]
stepIndex = 1

I've started to play around with your nice design system and implemented an stepper component. Please take a look and improve or leave a comment if something can be improved.