### PR TITLE
ci: remove useless token when reading PR metadata

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,8 +13,6 @@ jobs:
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v1
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge for Dependabot PRs
         if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.dependabot.outputs.update-type == 'version-update:semver-minor'}}
         env:


### PR DESCRIPTION
As you can see in the [official documentation](https://github.com/dependabot/fetch-metadata), there's no need to provide a token for this step. This step is just reading metadata from the context object so it doesn't need to perform any authorized API calls.