### PR TITLE
feat: add b2b-text component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52485,7 +52485,8 @@
           }
         },
         "trim-newlines": {
-          "version": "3.0.1",
+          "version": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.1.1.tgz",
+          "integrity": "sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==",
           "dev": true
         },
         "type-fest": {

--- a/packages/core-components/src/components.d.ts
+++ b/packages/core-components/src/components.d.ts
@@ -912,6 +912,23 @@ export namespace Components {
         "type": TableRowgroupTypes;
     }
     /**
+     * Text component to render text content.
+     */
+    interface B2bText {
+        /**
+          * The alignment of the text.
+         */
+        "align": 'left' | 'right' | 'center';
+        /**
+          * The size of the text.
+         */
+        "size": '50' | '100';
+        /**
+          * The weight of the text.
+         */
+        "weight": 'bold' | 'normal';
+    }
+    /**
      * Text Area Component
      * Initial story: https://otto-eg.atlassian.net/browse/B2BDS-96
      */
@@ -1819,6 +1836,15 @@ declare global {
         prototype: HTMLB2bTableRowgroupElement;
         new (): HTMLB2bTableRowgroupElement;
     };
+    /**
+     * Text component to render text content.
+     */
+    interface HTMLB2bTextElement extends Components.B2bText, HTMLStencilElement {
+    }
+    var HTMLB2bTextElement: {
+        prototype: HTMLB2bTextElement;
+        new (): HTMLB2bTextElement;
+    };
     interface HTMLB2bTextareaElementEventMap {
         "b2b-focus": FocusEvent;
         "b2b-blur": FocusEvent;
@@ -1985,6 +2011,7 @@ declare global {
         "b2b-table-header": HTMLB2bTableHeaderElement;
         "b2b-table-row": HTMLB2bTableRowElement;
         "b2b-table-rowgroup": HTMLB2bTableRowgroupElement;
+        "b2b-text": HTMLB2bTextElement;
         "b2b-textarea": HTMLB2bTextareaElement;
         "b2b-toggle-button": HTMLB2bToggleButtonElement;
         "b2b-toggle-chip": HTMLB2bToggleChipElement;
@@ -3006,6 +3033,23 @@ declare namespace LocalJSX {
         "type"?: TableRowgroupTypes;
     }
     /**
+     * Text component to render text content.
+     */
+    interface B2bText {
+        /**
+          * The alignment of the text.
+         */
+        "align"?: 'left' | 'right' | 'center';
+        /**
+          * The size of the text.
+         */
+        "size"?: '50' | '100';
+        /**
+          * The weight of the text.
+         */
+        "weight"?: 'bold' | 'normal';
+    }
+    /**
      * Text Area Component
      * Initial story: https://otto-eg.atlassian.net/browse/B2BDS-96
      */
@@ -3285,6 +3329,7 @@ declare namespace LocalJSX {
         "b2b-table-header": B2bTableHeader;
         "b2b-table-row": B2bTableRow;
         "b2b-table-rowgroup": B2bTableRowgroup;
+        "b2b-text": B2bText;
         "b2b-textarea": B2bTextarea;
         "b2b-toggle-button": B2bToggleButton;
         "b2b-toggle-chip": B2bToggleChip;
@@ -3366,6 +3411,10 @@ declare module "@stencil/core" {
             "b2b-table-header": LocalJSX.B2bTableHeader & JSXBase.HTMLAttributes<HTMLB2bTableHeaderElement>;
             "b2b-table-row": LocalJSX.B2bTableRow & JSXBase.HTMLAttributes<HTMLB2bTableRowElement>;
             "b2b-table-rowgroup": LocalJSX.B2bTableRowgroup & JSXBase.HTMLAttributes<HTMLB2bTableRowgroupElement>;
+            /**
+             * Text component to render text content.
+             */
+            "b2b-text": LocalJSX.B2bText & JSXBase.HTMLAttributes<HTMLB2bTextElement>;
             /**
              * Text Area Component
              * Initial story: https://otto-eg.atlassian.net/browse/B2BDS-96

--- a/packages/core-components/src/components/text/readme.md
+++ b/packages/core-components/src/components/text/readme.md
@@ -1,0 +1,23 @@
+# b2b-text
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Overview
+
+Text component to render text content.
+
+## Properties
+
+| Property | Attribute | Description                | Type                            | Default    |
+| -------- | --------- | -------------------------- | ------------------------------- | ---------- |
+| `align`  | `align`   | The alignment of the text. | `"center" \| "left" \| "right"` | `'left'`   |
+| `size`   | `size`    | The size of the text.      | `"100" \| "50"`                 | `'100'`    |
+| `weight` | `weight`  | The weight of the text.    | `"bold" \| "normal"`            | `'normal'` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/core-components/src/components/text/text.docs.mdx
+++ b/packages/core-components/src/components/text/text.docs.mdx
@@ -1,0 +1,65 @@
+import {
+  Story,
+  ArgsTable,
+  PRIMARY_STORY,
+  Primary,
+  Source,
+  Canvas,
+  Meta,
+} from '@storybook/blocks';
+
+import * as TextStories from './text.stories';
+
+<Meta of={TextStories} />
+
+# Text Component
+
+This component can be used to render running text. Its a wrapper around the `<span>` tag.
+
+### Example
+
+<Canvas withSource="open" withToolbar={false}>
+  <Story id="components-content-text--story-010-default" />
+</Canvas>
+
+NOTE: All attributes are optional. The component can simply be used like this without specifying any attributes:
+
+<Source code={`<b2b-text>Simple Text</b2b-text>`} />
+
+## Properties
+
+<br />
+
+### Weight
+
+<Canvas withSource="closed" withToolbar={false}>
+  <Story id="components-content-text--story-020-bold" />
+</Canvas>
+
+### Size
+
+Can be used for hints and asterisk texts, among others.
+
+<Canvas withSource="closed" withToolbar={false}>
+  <Story id="components-content-text--story-030-small" />
+</Canvas>
+
+### Align
+
+#### Center aligned text
+
+<Canvas withSource="closed" withToolbar={false}>
+  <Story id="components-content-text--story-040-center" />
+</Canvas>
+
+#### Right aligned text
+
+<Canvas withSource="closed" withToolbar={false}>
+  <Story id="components-content-text--story-050-right" />
+</Canvas>
+
+## Attributes
+
+<ArgsTable story={PRIMARY_STORY} />
+Changes made to the attributes in the above table will reflect in the example below:
+<Primary />

--- a/packages/core-components/src/components/text/text.e2e.tsx
+++ b/packages/core-components/src/components/text/text.e2e.tsx
@@ -1,0 +1,15 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('B2B-Text', () => {
+  let page;
+  beforeEach(async () => {
+    page = await newE2EPage();
+    await page.setContent(`<b2b-text>Text</b2b-text>`);
+  });
+
+  it('should render text component', async () => {
+    const element = await page.find('b2b-text');
+    expect(element).not.toBeNull();
+    expect(element).toEqualText('Text');
+  });
+});

--- a/packages/core-components/src/components/text/text.scss
+++ b/packages/core-components/src/components/text/text.scss
@@ -1,0 +1,37 @@
+@use '../../global/b2b-styles';
+
+.b2b-text {
+  font-family: var(--b2b-font-family-default);
+  color: var(--b2b-color-copy-default);
+  margin: 0 0 var(--b2b-size-30);
+
+  &--size-50 {
+    font-size: var(--b2b-size-copy-50);
+    line-height: var(--b2b-size-copy-line-height-75);
+  }
+
+  &--size-100 {
+    font-size: var(--b2b-size-copy-100);
+    line-height: var(--b2b-size-copy-line-height-100);
+  }
+
+  &--weight-normal {
+    font-weight: var(--b2b-font-weight-normal);
+  }
+
+  &--weight-bold {
+    font-weight: var(--b2b-font-weight-bold);
+  }
+
+  &--align-left {
+    text-align: left;
+  }
+
+  &--align-right {
+    text-align: right;
+  }
+
+  &--align-center {
+    text-align: center;
+  }
+}

--- a/packages/core-components/src/components/text/text.stories.tsx
+++ b/packages/core-components/src/components/text/text.stories.tsx
@@ -1,0 +1,53 @@
+import { Meta, Story } from '@storybook/web-components';
+import { html } from 'lit-html';
+import { getArgTypes } from '../../docs/config/utils';
+
+const template: Story = ({ weight, size, align }) => {
+  return html`<b2b-text weight="${weight}" size="${size}" align="${align}">
+    Far far away, behind the word mountains, far from the countries Vokalia and
+    Consonantia, there live the blind texts. Separated they live in
+    Bookmarksgrove right at the coast of the Semantics, a large language ocean.
+    A small river named Duden flows by their place and supplies it with the
+    necessary regelialia. It is a paradisematic country, in which roasted parts
+    of sentences fly into your mouth. Even the all-powerful Pointing has no
+    control about the blind texts it is an almost unorthographic life One day
+    however a small line of blind text by the name of Lorem Ipsum decided to
+    leave for the far World of Grammar. The Big Oxmox advised her not to do so,
+    because there were thousands of bad Commas, wild Question Marks and devious
+    Semikoli, but the Little Blind Text didn’t listen.
+  </b2b-text>`;
+};
+
+const defaultArgs = {
+  weight: 'normal',
+  size: '100',
+  align: 'left',
+};
+
+export const story010Default = template.bind({});
+story010Default.args = defaultArgs;
+story010Default.storyName = 'Default';
+
+export const story020Bold = template.bind({});
+story020Bold.args = { ...defaultArgs, weight: 'bold' };
+story020Bold.storyName = 'Bold text';
+
+export const story030Small = template.bind({});
+story030Small.args = { ...defaultArgs, size: '50' };
+story030Small.storyName = 'Small text';
+
+export const story040Center = template.bind({});
+story040Center.args = { ...defaultArgs, align: 'center' };
+story040Center.storyName = 'Center aligned text';
+
+export const story050Right = template.bind({});
+story050Right.args = { ...defaultArgs, align: 'right' };
+story050Right.storyName = 'Right aligned text';
+
+const argTypes = getArgTypes('b2b-text');
+
+export default {
+  title: 'Components/Content/Text',
+  argTypes: argTypes,
+  viewMode: 'docs',
+} as Meta;

--- a/packages/core-components/src/components/text/text.tsx
+++ b/packages/core-components/src/components/text/text.tsx
@@ -1,0 +1,34 @@
+import { Component, h, Prop } from '@stencil/core';
+
+/**
+ * Text component to render text content.
+ */
+@Component({
+  tag: 'b2b-text',
+  styleUrl: 'text.scss',
+  shadow: true,
+})
+export class TextComponent {
+  /** The weight of the text. */
+  @Prop() weight: 'bold' | 'normal' = 'normal';
+
+  /** The size of the text. */
+  @Prop() size: '50' | '100' = '100';
+
+  /** The alignment of the text. */
+  @Prop() align: 'left' | 'right' | 'center' = 'left';
+
+  render() {
+    return (
+      <span
+        class={{
+          'b2b-text': true,
+          ['b2b-text--size-' + this.size]: true,
+          ['b2b-text--weight-' + this.weight]: true,
+          ['b2b-text--align-' + this.align]: true,
+        }}>
+        <slot></slot>
+      </span>
+    );
+  }
+}

--- a/packages/core-components/src/docs/config/components-args.json
+++ b/packages/core-components/src/docs/config/components-args.json
@@ -91,7 +91,7 @@
           "summary": "null"
         }
       },
-      "description": "If set to true, the browser will attempt to donwload and save the URL instead of opening it. The name of the created file\r\ndefaults to the URL string, but can be changed by the user."
+      "description": "If set to true, the browser will attempt to donwload and save the URL instead of opening it. The name of the created file\ndefaults to the URL string, but can be changed by the user."
     },
     "href": {
       "table": {
@@ -214,7 +214,7 @@
         },
         "defaultValue": {}
       },
-      "description": "If set to true, the browser will attempt to donwload and save the URL instead of opening it. The name of the created file\r\ndefaults to the URL string, but can be changed by the user."
+      "description": "If set to true, the browser will attempt to donwload and save the URL instead of opening it. The name of the created file\ndefaults to the URL string, but can be changed by the user."
     },
     "href": {
       "table": {
@@ -2106,7 +2106,7 @@
           "summary": "false"
         }
       },
-      "description": "A boolean that indicates whether the modal can be dismissed by clicking\r\nin the backdrop outside the modal."
+      "description": "A boolean that indicates whether the modal can be dismissed by clicking\nin the backdrop outside the modal."
     },
     "escDismiss": {
       "control": {
@@ -2120,7 +2120,7 @@
           "summary": "true"
         }
       },
-      "description": "A boolean to indicate whether the modal can be dismissed by pressing\r\nthe escape key on the keyboard"
+      "description": "A boolean to indicate whether the modal can be dismissed by pressing\nthe escape key on the keyboard"
     },
     "heading": {
       "table": {
@@ -2630,7 +2630,7 @@
         },
         "defaultValue": {}
       },
-      "description": "The color of the border of the circle around the icon or text.\r\nUse any type including hex, rgb or css custom properties\r\nas long as you pass it as a string"
+      "description": "The color of the border of the circle around the icon or text.\nUse any type including hex, rgb or css custom properties\nas long as you pass it as a string"
     },
     "color": {
       "table": {
@@ -2641,7 +2641,7 @@
           "summary": "'var(--b2b-color-info-50)'"
         }
       },
-      "description": "The color of the circle around the icon or text.\r\nUse any type including hex, rgb or css custom properties\r\nas long as you pass it as a string"
+      "description": "The color of the circle around the icon or text.\nUse any type including hex, rgb or css custom properties\nas long as you pass it as a string"
     },
     "contentColor": {
       "table": {
@@ -2652,7 +2652,7 @@
           "summary": "'var(--b2b-color-copy-default)'"
         }
       },
-      "description": "The color of the text or icon within the circle.\r\nUse any type including hex, rgb or css custom properties\r\nas long as you pass it as a string"
+      "description": "The color of the text or icon within the circle.\nUse any type including hex, rgb or css custom properties\nas long as you pass it as a string"
     }
   },
   "b2b-scrollable-container": {},
@@ -2820,7 +2820,7 @@
           "summary": "false"
         }
       },
-      "description": "Determines if the Tab Group will do it's own navigation. Per default, it will use internal navigation.\r\nSet it to true if you want to use external, route-based navigation."
+      "description": "Determines if the Tab Group will do it's own navigation. Per default, it will use internal navigation.\nSet it to true if you want to use external, route-based navigation."
     }
   },
   "b2b-tab-panel": {},
@@ -2842,7 +2842,7 @@
           "summary": "TableSizes.EXPAND"
         }
       },
-      "description": "The size of the table. Both will expand to 100% of parent size.\r\nExpand cells will use as much space as content needs and text will wrap.\r\nEqual will keep all column sizes proportional to the number of columns.\r\nColspan behaves same as equal, but allows you to set a colspan attribute on individual columns or cells\r\nto make them span more than one column."
+      "description": "The size of the table. Both will expand to 100% of parent size.\nExpand cells will use as much space as content needs and text will wrap.\nEqual will keep all column sizes proportional to the number of columns.\nColspan behaves same as equal, but allows you to set a colspan attribute on individual columns or cells\nto make them span more than one column."
     }
   },
   "b2b-table-cell": {
@@ -2919,7 +2919,7 @@
           "summary": "true"
         }
       },
-      "description": "Whether text should wrap or truncate.\r\nIt will only truncate when table size is equal\r\n*"
+      "description": "Whether text should wrap or truncate.\nIt will only truncate when table size is equal\n*"
     }
   },
   "b2b-table-header": {
@@ -2996,7 +2996,7 @@
           "summary": "TableSizes.EXPAND"
         }
       },
-      "description": "The size of the cell. Follows table size.\r\nWhen size is equal and textWrap is false, the text will truncate with Ellipsis.\r\nOther sizes won't affect cell current implementation."
+      "description": "The size of the cell. Follows table size.\nWhen size is equal and textWrap is false, the text will truncate with Ellipsis.\nOther sizes won't affect cell current implementation."
     },
     "sortDirection": {
       "options": [
@@ -3110,7 +3110,7 @@
           "summary": "false"
         }
       },
-      "description": "Renders the rowgroup as an accordion. Both header and body must have accordion set to true.\r\nOne table can contain multiple rowgroups of type body, each of which represents an accordion row with children."
+      "description": "Renders the rowgroup as an accordion. Both header and body must have accordion set to true.\nOne table can contain multiple rowgroups of type body, each of which represents an accordion row with children."
     },
     "fixed": {
       "control": {
@@ -3138,7 +3138,7 @@
           "summary": "false"
         }
       },
-      "description": "Only use when accordion property is true.\r\nWill render the accordion opened if set to true. By default, is false."
+      "description": "Only use when accordion property is true.\nWill render the accordion opened if set to true. By default, is false."
     },
     "selectable": {
       "control": {
@@ -3171,7 +3171,64 @@
           "summary": "TableRowgroupTypes.HEADER"
         }
       },
-      "description": "Rowgroup allows grouping rows by context: header, body or footer.\r\nHeader rows are by default not highlightable on mouse over."
+      "description": "Rowgroup allows grouping rows by context: header, body or footer.\nHeader rows are by default not highlightable on mouse over."
+    }
+  },
+  "b2b-text": {
+    "align": {
+      "options": [
+        "center",
+        "left",
+        "right"
+      ],
+      "control": {
+        "type": "radio"
+      },
+      "table": {
+        "type": {
+          "summary": "string"
+        },
+        "defaultValue": {
+          "summary": "'left'"
+        }
+      },
+      "description": "The alignment of the text."
+    },
+    "size": {
+      "options": [
+        "100",
+        "50"
+      ],
+      "control": {
+        "type": "radio"
+      },
+      "table": {
+        "type": {
+          "summary": "string"
+        },
+        "defaultValue": {
+          "summary": "'100'"
+        }
+      },
+      "description": "The size of the text."
+    },
+    "weight": {
+      "options": [
+        "bold",
+        "normal"
+      ],
+      "control": {
+        "type": "radio"
+      },
+      "table": {
+        "type": {
+          "summary": "string"
+        },
+        "defaultValue": {
+          "summary": "'normal'"
+        }
+      },
+      "description": "The weight of the text."
     }
   },
   "b2b-textarea": {
@@ -3647,7 +3704,7 @@
           "summary": "true"
         }
       },
-      "description": "Defaults to true. It will show a checkmark icon when a step is completed.\r\nSet as false to show the step number"
+      "description": "Defaults to true. It will show a checkmark icon when a step is completed.\nSet as false to show the step number"
     },
     "custom": {
       "control": {
@@ -3661,7 +3718,7 @@
           "summary": "false"
         }
       },
-      "description": "By default, is false, where the wizard will handle steps states.\r\nIf set to true, steps state must be handled manually."
+      "description": "By default, is false, where the wizard will handle steps states.\nIf set to true, steps state must be handled manually."
     }
   },
   "b2b-wizard-icon": {
@@ -3677,7 +3734,7 @@
           "summary": "true"
         }
       },
-      "description": "Defaults to true. It will show a checkmark icon when a step is completed.\r\nSet as false to show the step number"
+      "description": "Defaults to true. It will show a checkmark icon when a step is completed.\nSet as false to show the step number"
     },
     "state": {
       "options": [
@@ -3733,7 +3790,7 @@
           "summary": "true"
         }
       },
-      "description": "Defaults to true. It will show a checkmark icon when a step is completed.\r\nSet as false to show the step number"
+      "description": "Defaults to true. It will show a checkmark icon when a step is completed.\nSet as false to show the step number"
     },
     "state": {
       "options": [

--- a/packages/react-components/src/components/stencil-generated/index.ts
+++ b/packages/react-components/src/components/stencil-generated/index.ts
@@ -54,6 +54,7 @@ export const B2bTableCell = /*@__PURE__*/createReactComponent<JSX.B2bTableCell, 
 export const B2bTableHeader = /*@__PURE__*/createReactComponent<JSX.B2bTableHeader, HTMLB2bTableHeaderElement>('b2b-table-header');
 export const B2bTableRow = /*@__PURE__*/createReactComponent<JSX.B2bTableRow, HTMLB2bTableRowElement>('b2b-table-row');
 export const B2bTableRowgroup = /*@__PURE__*/createReactComponent<JSX.B2bTableRowgroup, HTMLB2bTableRowgroupElement>('b2b-table-rowgroup');
+export const B2bText = /*@__PURE__*/createReactComponent<JSX.B2bText, HTMLB2bTextElement>('b2b-text');
 export const B2bTextarea = /*@__PURE__*/createReactComponent<JSX.B2bTextarea, HTMLB2bTextareaElement>('b2b-textarea');
 export const B2bToggleButton = /*@__PURE__*/createReactComponent<JSX.B2bToggleButton, HTMLB2bToggleButtonElement>('b2b-toggle-button');
 export const B2bToggleChip = /*@__PURE__*/createReactComponent<JSX.B2bToggleChip, HTMLB2bToggleChipElement>('b2b-toggle-chip');

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /b2b
 
 COPY ./packages /b2b/packages
 COPY ./package.json /b2b/package.json
+COPY ./package-lock.json /b2b/package-lock.json
 COPY ./scripts /b2b/scripts
 COPY ./DEV-GUIDELINES.md /b2b
 COPY ./CHANGELOG.md /b2b

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -6,7 +6,6 @@ WORKDIR /b2b
 
 COPY ./packages /b2b/packages
 COPY ./package.json /b2b/package.json
-COPY ./package-lock.json /b2b/package-lock.json
 COPY ./scripts /b2b/scripts
 COPY ./DEV-GUIDELINES.md /b2b
 COPY ./CHANGELOG.md /b2b


### PR DESCRIPTION
This component allows writing text that uses the correct fonts and style just like `b2b-paragraph` does but in a span instead of a `p`. This allows, for example, avoiding the traditional new line and margin-bottom associated with a `p`.