### PR TITLE
fix(FlyoutMenuOption): added shadow:true & css

### DIFF
--- a/packages/core-components/src/components/flyout-menu/flyout-menu-option.scss
+++ b/packages/core-components/src/components/flyout-menu/flyout-menu-option.scss
@@ -1,0 +1,23 @@
+@use '../../global/b2b-styles';
+
+:host {
+  display: block;
+  padding: var(--b2b-size-15) var(--b2b-size-30) 5px var(--b2b-size-30);
+  border-bottom: 1px solid transparent;
+  cursor: pointer;
+}
+
+:host(.b2b-flyout-menu__option:hover),
+:host(.b2b-flyout-menu__option:focus) {
+  background-color: var(--b2b-color-table-selected-hover);
+  outline: none;
+}
+
+:host(.b2b-flyout-menu__option--disabled) {
+  pointer-events: none;
+  color: var(--b2b-color-grey-200);
+}
+
+:host(.b2b-flyout-menu__option--separator) {
+  border-bottom: 1px solid var(--b2b-color-grey-200);
+}

--- a/packages/core-components/src/components/flyout-menu/flyout-menu-option.tsx
+++ b/packages/core-components/src/components/flyout-menu/flyout-menu-option.tsx
@@ -11,7 +11,8 @@ import { OptionSelectedEventDetail } from '../../utils/interfaces/form.interface
 
 @Component({
   tag: 'b2b-flyout-menu-option',
-  styleUrl: 'flyout-menu.scss',
+  styleUrl: 'flyout-menu-option.scss',
+  shadow: true,
 })
 export class FlyoutMenuOptionComponent {
   /** The option name. */

--- a/packages/core-components/src/components/flyout-menu/flyout-menu.e2e.tsx
+++ b/packages/core-components/src/components/flyout-menu/flyout-menu.e2e.tsx
@@ -82,7 +82,9 @@ describe('B2B-FlyoutMenu', () => {
     icon.click();
     await page.waitForChanges();
 
-    const flyoutMenuOption = await page.find({ text: 'option3' });
+    const flyoutMenuOption = await page.find(
+      'b2b-flyout-menu-option[option="option3"]',
+    );
     flyoutMenuOption.click();
     await page.waitForChanges();
 


### PR DESCRIPTION
Hi Team,

Recently our team tried to replace our custom flyout menu with the flyout menu from [b2b-design-system](https://b2b-design-system.otto.market/?path=/docs/components-interaction-flyout-menu--docs), although everything was working fine but we observed some hydration issues in browser console(image below) on refresh.

![image](https://github.com/user-attachments/assets/a4a7cdb4-269e-43b8-8210-3f747b3beae7)

This PR is to fix those hydration issue's observed in browser(on page refresh) while using b2b-flyout-menu.

This fix will turn `shadow` as `true` for nested b2b-flyout-menu-option child component and a separate .css file for the same component. 
