### PR TITLE
fix(Table): [GC-2220] accordion table rows now add control cells correctly on each first render

### DIFF
--- a/packages/core-components/src/components.d.ts
+++ b/packages/core-components/src/components.d.ts
@@ -11,7 +11,7 @@ import { IconName } from "./components/icon/types";
 import { IconName as IconName1 } from "./components/icon-100/types";
 import { IconName as IconName2 } from "./components/icon-50/types";
 import { BeforeCloseEventDetail } from "./utils/interfaces/status.interface";
-import { ContentAlignment, TableAccordionRowTypes, TableColourOptions, TableRowgroupTypes, TableSizes, TableSortDirections } from "./utils/types/table.types";
+import { ContentAlignment, TableColourOptions, TableRowgroupTypes, TableSizes, TableSortDirections } from "./utils/types/table.types";
 import { CheckboxEventDetail as CheckboxEventDetail1 } from "./components";
 import { TableAccordionSelectedEventDetail } from "./utils/interfaces/content.interface";
 import { WizardStatus, WizardSteps } from "./utils/types/wizard.types";
@@ -21,7 +21,7 @@ export { IconName } from "./components/icon/types";
 export { IconName as IconName1 } from "./components/icon-100/types";
 export { IconName as IconName2 } from "./components/icon-50/types";
 export { BeforeCloseEventDetail } from "./utils/interfaces/status.interface";
-export { ContentAlignment, TableAccordionRowTypes, TableColourOptions, TableRowgroupTypes, TableSizes, TableSortDirections } from "./utils/types/table.types";
+export { ContentAlignment, TableColourOptions, TableRowgroupTypes, TableSizes, TableSortDirections } from "./utils/types/table.types";
 export { CheckboxEventDetail as CheckboxEventDetail1 } from "./components";
 export { TableAccordionSelectedEventDetail } from "./utils/interfaces/content.interface";
 export { WizardStatus, WizardSteps } from "./utils/types/wizard.types";
@@ -740,6 +740,10 @@ export namespace Components {
          */
         "align": 'left' | 'right' | 'center';
         /**
+          * The positioning of the paragraph in the page flow. Defaults to native block behavior.
+         */
+        "display": 'inline' | 'inline-block' | 'block';
+        /**
           * Whether or not the paragraph has a bottom margin. Defaults to true.
          */
         "margin": boolean;
@@ -990,7 +994,6 @@ export namespace Components {
         "totalCols"?: number;
     }
     interface B2bTableRow {
-        "accordionType": TableAccordionRowTypes;
         /**
           * If a selectable row is currently checked. Per default, it is false.
          */
@@ -3084,6 +3087,10 @@ declare namespace LocalJSX {
          */
         "align"?: 'left' | 'right' | 'center';
         /**
+          * The positioning of the paragraph in the page flow. Defaults to native block behavior.
+         */
+        "display"?: 'inline' | 'inline-block' | 'block';
+        /**
           * Whether or not the paragraph has a bottom margin. Defaults to true.
          */
         "margin"?: boolean;
@@ -3370,7 +3377,6 @@ declare namespace LocalJSX {
         "totalCols"?: number;
     }
     interface B2bTableRow {
-        "accordionType"?: TableAccordionRowTypes;
         /**
           * If a selectable row is currently checked. Per default, it is false.
          */

--- a/packages/core-components/src/components/table/table-row/table-row.tsx
+++ b/packages/core-components/src/components/table/table-row/table-row.tsx
@@ -11,7 +11,6 @@ import {
   Listen,
 } from '@stencil/core';
 import {
-  TableAccordionRowTypes,
   TableColourOptions,
   TableSizes,
 } from '../../../utils/types/table.types';
@@ -19,6 +18,7 @@ import {
   B2bCheckboxCustomEvent,
   CheckboxEventDetail,
 } from '../../../components';
+import { isFirstRow } from '../utils';
 
 @Component({
   tag: 'b2b-table-row',
@@ -33,9 +33,6 @@ export class TableRowComponent {
 
   /** Background color of the row. Use it semantically. This color selection have hover states **/
   @Prop() color: TableColourOptions = 'default';
-
-  /** @internal Determined by the parent rowgroup for accordion rowgroups. */
-  @Prop() accordionType: TableAccordionRowTypes;
 
   /** @internal Whether the parent rowgroup is selectable. */
   @Prop() selectable: boolean;
@@ -114,8 +111,13 @@ export class TableRowComponent {
   };
 
   private getRowColor = () => {
-    if (this.accordionType === TableAccordionRowTypes.PARENT)
+    if (
+      this.isAccordion() &&
+      isFirstRow(this.hostElement) &&
+      !this.isHeader()
+    ) {
       return TableColourOptions.GROUP;
+    }
     return this.color;
   };
 
@@ -126,11 +128,21 @@ export class TableRowComponent {
   };
 
   private getParentRowGroup = () => {
-    return this.hostElement.closest('b2b-table-rowgroup');
+    return this.hostElement.closest(
+      'b2b-table-rowgroup',
+    ) as HTMLB2bTableRowgroupElement;
+  };
+
+  private isAccordion = () => {
+    return this.getParentRowGroup().hasAttribute('accordion');
+  };
+
+  private isHeader = () => {
+    return this.getParentRowGroup().type === 'header';
   };
 
   private getCheckbox = () => {
-    let parent = this.getParentRowGroup();
+    const parent = this.getParentRowGroup();
     if (this.shouldAddCheckbox()) {
       if (parent.type === 'header') {
         return (
@@ -156,34 +168,60 @@ export class TableRowComponent {
   };
 
   private getAccordionColumns = () => {
-    if (this.accordionType != undefined) {
-      switch (this.accordionType) {
-        case TableAccordionRowTypes.HEADER:
-          return (
-            <b2b-table-header class="b2b-table-row__control-cell--accordion"></b2b-table-header>
-          );
-        case TableAccordionRowTypes.PARENT:
-          return (
-            <b2b-table-cell>
-              <button
-                onClick={this.toggleOpen}
-                class={{
-                  'b2b-table-row__accordion-icon': true,
-                  'b2b-table-row__accordion-icon--open': this.isOpen,
-                }}>
-                <b2b-icon
-                  icon="b2b_icon-arrow-right"
-                  clickable={true}></b2b-icon>
-              </button>
-            </b2b-table-cell>
-          );
-        case TableAccordionRowTypes.CHILD:
-          return (
-            <b2b-table-cell class="b2b-table-row__control-cell--accordion"></b2b-table-cell>
-          );
+    if (this.isAccordion() && !this.isHeader()) {
+      if (isFirstRow(this.hostElement)) {
+        return (
+          <b2b-table-cell>
+            <button
+              onClick={this.toggleOpen}
+              class={{
+                'b2b-table-row__accordion-icon': true,
+                'b2b-table-row__accordion-icon--open': this.isOpen,
+              }}>
+              <b2b-icon icon="b2b_icon-arrow-right" clickable={true}></b2b-icon>
+            </button>
+          </b2b-table-cell>
+        );
       }
+      return (
+        <b2b-table-cell class="b2b-table-row__control-cell--accordion"></b2b-table-cell>
+      );
+    } else if (this.isAccordion() && this.isHeader()) {
+      return (
+        <b2b-table-header class="b2b-table-row__control-cell--accordion"></b2b-table-header>
+      );
     }
   };
+
+  // private getAccordionColumns = () => {
+  //   if (this.accordionType != undefined) {
+  //     switch (this.accordionType) {
+  //       case TableAccordionRowTypes.HEADER:
+  //         return (
+  //           <b2b-table-header class="b2b-table-row__control-cell--accordion"></b2b-table-header>
+  //         );
+  //       case TableAccordionRowTypes.PARENT:
+  //         return (
+  //           <b2b-table-cell>
+  //             <button
+  //               onClick={this.toggleOpen}
+  //               class={{
+  //                 'b2b-table-row__accordion-icon': true,
+  //                 'b2b-table-row__accordion-icon--open': this.isOpen,
+  //               }}>
+  //               <b2b-icon
+  //                 icon="b2b_icon-arrow-right"
+  //                 clickable={true}></b2b-icon>
+  //             </button>
+  //           </b2b-table-cell>
+  //         );
+  //       case TableAccordionRowTypes.CHILD:
+  //         return (
+  //           <b2b-table-cell class="b2b-table-row__control-cell--accordion"></b2b-table-cell>
+  //         );
+  //     }
+  //   }
+  // };
 
   render() {
     return (

--- a/packages/core-components/src/components/table/table-row/table-row.tsx
+++ b/packages/core-components/src/components/table/table-row/table-row.tsx
@@ -193,36 +193,6 @@ export class TableRowComponent {
     }
   };
 
-  // private getAccordionColumns = () => {
-  //   if (this.accordionType != undefined) {
-  //     switch (this.accordionType) {
-  //       case TableAccordionRowTypes.HEADER:
-  //         return (
-  //           <b2b-table-header class="b2b-table-row__control-cell--accordion"></b2b-table-header>
-  //         );
-  //       case TableAccordionRowTypes.PARENT:
-  //         return (
-  //           <b2b-table-cell>
-  //             <button
-  //               onClick={this.toggleOpen}
-  //               class={{
-  //                 'b2b-table-row__accordion-icon': true,
-  //                 'b2b-table-row__accordion-icon--open': this.isOpen,
-  //               }}>
-  //               <b2b-icon
-  //                 icon="b2b_icon-arrow-right"
-  //                 clickable={true}></b2b-icon>
-  //             </button>
-  //           </b2b-table-cell>
-  //         );
-  //       case TableAccordionRowTypes.CHILD:
-  //         return (
-  //           <b2b-table-cell class="b2b-table-row__control-cell--accordion"></b2b-table-cell>
-  //         );
-  //     }
-  //   }
-  // };
-
   render() {
     return (
       <Host

--- a/packages/core-components/src/components/table/table-rowgroup/table-rowgroup.tsx
+++ b/packages/core-components/src/components/table/table-rowgroup/table-rowgroup.tsx
@@ -10,7 +10,6 @@ import {
   EventEmitter,
 } from '@stencil/core';
 import {
-  TableAccordionRowTypes,
   TableRowgroupTypes,
   TableSizes,
 } from '../../../utils/types/table.types';
@@ -23,6 +22,7 @@ import {
   getFirstRow,
   getAllRows,
   getRemainingRows,
+  isFirstRow,
 } from '../utils';
 import { TableAccordionSelectedEventDetail } from '../../../utils/interfaces/content.interface';
 
@@ -73,10 +73,7 @@ export class TableRowgroupComponent {
     const target = event.target;
     const table = this.host.closest('b2b-table');
     const parentValue = getFirstRow(this.host).value ?? 'header';
-    if (
-      this.accordion &&
-      target.accordionType === TableAccordionRowTypes.PARENT
-    ) {
+    if (this.accordion && isFirstRow(target) && parentValue != 'header') {
       const children = getRemainingRows(this.host);
       this.toggleSelectAll(event, children);
     } else if (this.type === TableRowgroupTypes.HEADER) {
@@ -106,9 +103,7 @@ export class TableRowgroupComponent {
     children: HTMLB2bTableRowElement[],
   ) => {
     this.toggleList(children, event);
-    const rows = children.filter(
-      child => child.accordionType !== TableAccordionRowTypes.PARENT,
-    );
+    const rows = children.filter(child => !isFirstRow(child));
     this.selectedValues = [...rows]
       .filter(child => child.checked)
       .map(child => child.value);
@@ -132,21 +127,21 @@ export class TableRowgroupComponent {
     }
   }
 
-  private addAccordionControlColumn = () => {
-    const firstRow = getFirstRow(this.host);
+  // private addAccordionControlColumn = () => {
+  //   const firstRow = getFirstRow(this.host);
 
-    if (this.type === TableRowgroupTypes.HEADER) {
-      firstRow && (firstRow.accordionType = TableAccordionRowTypes.HEADER);
-    } else {
-      firstRow && (firstRow.accordionType = TableAccordionRowTypes.PARENT);
-    }
+  //   if (this.type === TableRowgroupTypes.HEADER) {
+  //     firstRow && (firstRow.accordionType = TableAccordionRowTypes.HEADER);
+  //   } else {
+  //     firstRow && (firstRow.accordionType = TableAccordionRowTypes.PARENT);
+  //   }
 
-    const children = getRemainingRows(this.host);
-    children &&
-      children.forEach(child => {
-        child.accordionType = TableAccordionRowTypes.CHILD;
-      });
-  };
+  //   const children = getRemainingRows(this.host);
+  //   children &&
+  //     children.forEach(child => {
+  //       child.accordionType = TableAccordionRowTypes.CHILD;
+  //     });
+  // };
 
   private addCheckboxColumn = () => {
     const children = getAllRows(this.host);
@@ -192,7 +187,6 @@ export class TableRowgroupComponent {
 
   componentWillLoad() {
     if (this.accordion) {
-      this.addAccordionControlColumn();
       this.toggleInitialVisibility();
     }
 

--- a/packages/core-components/src/components/table/table-rowgroup/table-rowgroup.tsx
+++ b/packages/core-components/src/components/table/table-rowgroup/table-rowgroup.tsx
@@ -127,22 +127,6 @@ export class TableRowgroupComponent {
     }
   }
 
-  // private addAccordionControlColumn = () => {
-  //   const firstRow = getFirstRow(this.host);
-
-  //   if (this.type === TableRowgroupTypes.HEADER) {
-  //     firstRow && (firstRow.accordionType = TableAccordionRowTypes.HEADER);
-  //   } else {
-  //     firstRow && (firstRow.accordionType = TableAccordionRowTypes.PARENT);
-  //   }
-
-  //   const children = getRemainingRows(this.host);
-  //   children &&
-  //     children.forEach(child => {
-  //       child.accordionType = TableAccordionRowTypes.CHILD;
-  //     });
-  // };
-
   private addCheckboxColumn = () => {
     const children = getAllRows(this.host);
     children.forEach(child => (child.selectable = true));

--- a/packages/core-components/src/components/table/table.e2e.tsx
+++ b/packages/core-components/src/components/table/table.e2e.tsx
@@ -245,18 +245,20 @@ describe('B2B-Table', () => {
     page = await newE2EPage();
     await page.setContent(tableWithAccordion);
     const firstRow = await page.find('#test-parent');
-    const type = await firstRow.getProperty('accordionType');
+    const arrowCell = await firstRow.find('b2b-table-row__accordion-icon');
 
-    expect(type).toEqualText('parent');
+    expect(arrowCell).toBeDefined();
   });
 
   it('should render all rows as accordion children when they are in the same rowgroup of type body in which accordion is true', async () => {
     page = await newE2EPage();
     await page.setContent(tableWithAccordion);
-    const firstRow = await page.find('#test-child');
-    const type = await firstRow.getProperty('accordionType');
+    const childRow = await page.find('#test-child');
+    const controlCell = await childRow.find(
+      '.b2b-table-row__control-cell--accordion',
+    );
 
-    expect(type).toEqualText('child');
+    expect(controlCell).toBeDefined();
   });
 
   it('should add an extra column for controls if accordion is true on a rowgroup', async () => {

--- a/packages/core-components/src/components/table/utils.ts
+++ b/packages/core-components/src/components/table/utils.ts
@@ -55,3 +55,9 @@ export function getFirstRow(
     return firstRow as HTMLB2bTableRowElement;
   }
 }
+
+export function isFirstRow(el: HTMLElement) {
+  // attr is nullable so
+  // eslint-disable-next-line @stencil-community/strict-boolean-conditions
+  return el.previousElementSibling ? false : true;
+}

--- a/packages/core-components/src/utils/types/table.types.ts
+++ b/packages/core-components/src/utils/types/table.types.ts
@@ -36,14 +36,6 @@ export const TableSortDirections = {
 export type TableSortDirections =
   (typeof TableSortDirections)[keyof typeof TableSortDirections];
 
-export const TableAccordionRowTypes = {
-  PARENT: 'parent',
-  CHILD: 'child',
-  HEADER: 'header',
-} as const;
-export type TableAccordionRowTypes =
-  (typeof TableAccordionRowTypes)[keyof typeof TableAccordionRowTypes];
-
 export const TableCheckboxTypes = {
   HEADER: 'header',
   ROW: 'row',


### PR DESCRIPTION
When a new child row was added after the initial render of the b2b-table-rowgroupelement that surrounded it, it would not get a control cell. That happened because the type prop that is checked on first render in the table row is set by the parent rowgroup, which only set the prop on children present at it's own first render.

Now each table row determines if it should add a control cell for the accordion on it's own render.