### PR TITLE
fix(Checkbox): use correct class to support multi-line label alignment

### DIFF
--- a/packages/core-components/src/components/checkbox/__snapshots__/checkbox.spec.tsx.snap
+++ b/packages/core-components/src/components/checkbox/__snapshots__/checkbox.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`should apply an error style if it is marked as invalid. 1`] = `
 <b2b-checkbox>
   <mock:shadow-root>
     <div class="b2b-checkbox b2b-checkbox--error">
-      <div class="b2b-checkbox-items">
+      <div class="b2b-checkbox__items">
         <input class="b2b-checkbox__input" type="checkbox">
         <b2b-input-label>
           <slot name="label">
@@ -24,7 +24,7 @@ exports[`should disable the checkbox 1`] = `
 <b2b-checkbox disabled="">
   <mock:shadow-root>
     <div class="b2b-checkbox b2b-checkbox--disabled">
-      <div class="b2b-checkbox-items">
+      <div class="b2b-checkbox__items">
         <input class="b2b-checkbox__input" disabled="" type="checkbox">
         <b2b-input-label disabled="">
           <slot name="label">
@@ -41,7 +41,7 @@ exports[`should render a hint if  invalid and disabled are true at the same time
 <b2b-checkbox disabled="">
   <mock:shadow-root>
     <div class="b2b-checkbox b2b-checkbox--disabled">
-      <div class="b2b-checkbox-items">
+      <div class="b2b-checkbox__items">
         <input class="b2b-checkbox__input" disabled="" type="checkbox">
         <b2b-input-label disabled="">
           <slot name="label">
@@ -61,7 +61,7 @@ exports[`should render a hint message if a hint string is specified 1`] = `
 <b2b-checkbox>
   <mock:shadow-root>
     <div class="b2b-checkbox">
-      <div class="b2b-checkbox-items">
+      <div class="b2b-checkbox__items">
         <input class="b2b-checkbox__input" type="checkbox">
         <b2b-input-label>
           <slot name="label">
@@ -81,7 +81,7 @@ exports[`should render an error message if an error is specified and it is marke
 <b2b-checkbox>
   <mock:shadow-root>
     <div class="b2b-checkbox b2b-checkbox--error">
-      <div class="b2b-checkbox-items">
+      <div class="b2b-checkbox__items">
         <input class="b2b-checkbox__input" type="checkbox">
         <b2b-input-label>
           <slot name="label">
@@ -101,7 +101,7 @@ exports[`should render the checkbox 1`] = `
 <b2b-checkbox>
   <mock:shadow-root>
     <div class="b2b-checkbox">
-      <div class="b2b-checkbox-items">
+      <div class="b2b-checkbox__items">
         <input class="b2b-checkbox__input" type="checkbox">
         <b2b-input-label>
           <slot name="label">

--- a/packages/core-components/src/components/checkbox/checkbox.tsx
+++ b/packages/core-components/src/components/checkbox/checkbox.tsx
@@ -149,7 +149,7 @@ export class CheckboxComponent {
             'b2b-checkbox--standalone': this.standalone,
             'b2b-checkbox--indeterminate': this.indeterminate,
           }}>
-          <div class="b2b-checkbox-items">
+          <div class="b2b-checkbox__items">
             {this.renderIcon()}
             <input
               class="b2b-checkbox__input"

--- a/packages/core-components/src/html/form.html
+++ b/packages/core-components/src/html/form.html
@@ -312,6 +312,8 @@
       <b2b-checkbox
         label="Checkbox with a very long label. Checkbox with a very long label. Checkbox with a very long label. Checkbox with a very long label."></b2b-checkbox>
       <b2b-checkbox
+        label="Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."></b2b-checkbox>
+      <b2b-checkbox
         ><span slot="label"
           >This is a custom label
           <b2b-icon-100


### PR DESCRIPTION
b2b-checkbox was using the non-defined `b2b-checkbox-items` class instead of the existing `b2b-checkbox__items` class, which ensures correct text alignment.