### PR TITLE
fix(textarea): fix textarea resize on input change

### DIFF
--- a/packages/core-components/src/components/textarea/readme.md
+++ b/packages/core-components/src/components/textarea/readme.md
@@ -17,7 +17,7 @@ Initial story: https://otto-eg.atlassian.net/browse/B2BDS-96
 | `disabled`    | `disabled`      | Whether or not the textarea is disabled. Per default it is false.                                      | `boolean`                                         | `false`     |
 | `error`       | `error`         | An optional error message that is displayed when the textarea is invalid. Per default it is undefined. | `string`                                          | `undefined` |
 | `focusOnLoad` | `focus-on-load` | Whether or not the textarea should be automatically focused on page load. Per default it is false.     | `boolean`                                         | `false`     |
-| `height`      | `height`        | The height of the text area                                                                            | `string`                                          | `undefined` |
+| `height`      | `height`        | The height of the text area                                                                            | `string`                                          | `''`        |
 | `hint`        | `hint`          | An optional hint for the textarea. Per default it is undefined.                                        | `string`                                          | `undefined` |
 | `invalid`     | `invalid`       | Whether or not the textarea should be displayed with error styles. Per default it is false.            | `boolean`                                         | `false`     |
 | `label`       | `label`         | The textarea label. This is optional.                                                                  | `string`                                          | `undefined` |

--- a/packages/core-components/src/components/textarea/textarea.tsx
+++ b/packages/core-components/src/components/textarea/textarea.tsx
@@ -62,7 +62,7 @@ export class B2BTextareaComponent {
   @Prop({ reflect: true }) maxLength?: number;
 
   /** The height of the text area */
-  @Prop() height?: string;
+  @Prop() height?: string = '';
 
   /** Emits whenever the textarea receives focus. */
   @Event({ eventName: 'b2b-focus' })

--- a/packages/core-components/src/docs/config/components-args.json
+++ b/packages/core-components/src/docs/config/components-args.json
@@ -4304,7 +4304,9 @@
         "type": {
           "summary": "string"
         },
-        "defaultValue": {}
+        "defaultValue": {
+          "summary": "''"
+        }
       },
       "description": "The height of the text area"
     },


### PR DESCRIPTION
When the height property isn't provided and the height is changed in the UI, textarea height resets on input change. This can be addressed by avoiding undefined height values.