### PR TITLE
[CCOP-114] Center numbers in wizard

### DIFF
--- a/packages/core-components/src/components/rounded-icon/rounded-icon.scss
+++ b/packages/core-components/src/components/rounded-icon/rounded-icon.scss
@@ -12,7 +12,7 @@
   width: 24px;
   height: 24px;
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: center;
   font-size: var(--b2b-size-copy-125);
   line-height: var(--b2b-size-copy-line-height-100);


### PR DESCRIPTION
Prerequisite for [CCOP-114](https://otto-eg.atlassian.net/browse/CCOP-114)

---

Vertically center the numbers in `b2b-wizard-step`s.

Previously:

![grafik](https://github.com/user-attachments/assets/fb37741d-7509-47cb-a00b-a0d70eed0b9e)

Now:

![grafik](https://github.com/user-attachments/assets/e8632732-ef53-4885-98b5-4120905edfe6)
