### PR TITLE
test: JELLY-10262: Expand multiselect-dropdown tests

### DIFF
--- a/packages/core-components/src/components/multiselect-dropdown/multiselect-dropdown.e2e.tsx
+++ b/packages/core-components/src/components/multiselect-dropdown/multiselect-dropdown.e2e.tsx
@@ -1,4 +1,5 @@
 import { newE2EPage } from '@stencil/core/testing';
+import { log } from 'console';
 
 describe('b2b-multiselect-dropdown', () => {
   it('should render with placeholder', async () => {
@@ -11,12 +12,37 @@ describe('b2b-multiselect-dropdown', () => {
     );
     expect(placeholder).not.toBeNull();
     expect(placeholder).toEqualText('Select an option');
+
+    const required = await page
+      .find('b2b-multiselect-dropdown >>> b2b-input-label')
+      .then(label => label.shadowRoot.querySelector('label'));
+    expect(required).not.toHaveClass('b2b-input-label--required');
   });
 
-  it('should render with hint message', async () => {
+  it('should render with given properties', async () => {
     const page = await newE2EPage({
-      html: `<b2b-multiselect-dropdown hint="Choose wisely!"></b2b-multiselect-dropdown>`,
+      html: `<b2b-multiselect-dropdown
+                label="The Label"
+                options-list="Option 1, Option 2, Option 3"
+                select-all-label="Select All"
+                search-placeholder="Search..."
+                hint="Choose wisely!"
+                required="true"
+                placeholder="Select an option">
+             </b2b-multiselect-dropdown>`,
     });
+
+    const placeholder = await page.find(
+      'b2b-multiselect-dropdown >>> .b2b-multiselect-dropdown__placeholder',
+    );
+
+    expect(placeholder).not.toBeNull();
+    expect(placeholder).toEqualText('Select an option');
+
+    const required = await page
+      .find('b2b-multiselect-dropdown >>> b2b-input-label')
+      .then(label => label.shadowRoot.querySelector('label'));
+    expect(required).toHaveClass('b2b-input-label--required');
 
     const hint = await page.find(
       'b2b-multiselect-dropdown >>> .b2b-multiselect-dropdown__hint',
@@ -25,9 +51,16 @@ describe('b2b-multiselect-dropdown', () => {
     expect(text).toBe('Choose wisely!');
   });
 
-  it('should open dropdown on click and displays options', async () => {
+  it('should open dropdown on click and display options', async () => {
     const page = await newE2EPage({
-      html: `<b2b-multiselect-dropdown placeholder="Choose" options-list="Swift Carrot, Happy Onion, Cool Tomato"></b2b-multiselect-dropdown>`,
+      html: `<b2b-multiselect-dropdown
+        placeholder="Choose"
+        options-list="Swift Carrot, Happy Onion, Cool Tomato"
+        select-all-label="Select All"
+        search-placeholder="Search..."
+        max-options-visible="2"
+      >
+      </b2b-multiselect-dropdown>`,
     });
 
     const trigger = await page.find(
@@ -36,15 +69,24 @@ describe('b2b-multiselect-dropdown', () => {
     await trigger.click();
     await page.waitForChanges();
 
-    const allOptions = await page.findAll(
+    const searchDiv = await page.find(
+      'b2b-multiselect-dropdown >>> .b2b-multiselect-dropdown__option__search input',
+    );
+    const allOptionsWithSelectAll = await page.findAll(
       'b2b-multiselect-dropdown >>> b2b-multiselect-option',
     );
-    expect(allOptions.length).toBeGreaterThan(1);
-    const checkbox = await allOptions[1].find('b2b-checkbox');
+    const selectAllCheckbox =
+      await allOptionsWithSelectAll[0].find('b2b-checkbox');
+
+    expect(searchDiv.getAttribute('placeholder')).toContain('Search...');
+    expect(allOptionsWithSelectAll.length).toBe(4);
+    expect(selectAllCheckbox.getAttribute('value')).toBe('Select All');
+
+    const checkbox = await allOptionsWithSelectAll[1].find('b2b-checkbox');
     await checkbox.click();
 
     const values = await Promise.all(
-      allOptions.slice(1).map(async opt => {
+      allOptionsWithSelectAll.slice(1).map(async opt => {
         const cb = await opt.find('b2b-checkbox');
         return cb.getAttribute('value');
       }),
@@ -114,6 +156,34 @@ describe('b2b-multiselect-dropdown', () => {
       'b2b-multiselect-dropdown >>> b2b-chip-component',
     );
     expect(chips.length).toBe(2);
+  });
+
+  it('should render only two chips and "..." when maxOptionsVisible is set to 2', async () => {
+    const page = await newE2EPage({
+      html: `<b2b-multiselect-dropdown options-list="Alpha, Beta, Gamma, Delta" max-options-visible="2"></b2b-multiselect-dropdown>`,
+    });
+
+    const trigger = await page.find(
+      'b2b-multiselect-dropdown >>> .b2b-multiselect-dropdown',
+    );
+    await page.waitForChanges();
+    await trigger.click();
+    await page.waitForChanges();
+
+    const spy = await page.spyOnEvent('b2b-selected');
+    const allOptions = await page.findAll(
+      'b2b-multiselect-dropdown >>> b2b-multiselect-option',
+    );
+    const checkbox = await allOptions[0].find('b2b-checkbox');
+    await checkbox.click();
+    await page.waitForChanges();
+
+    expect(spy).toHaveReceivedEvent();
+
+    const chips = await page.findAll(
+      'b2b-multiselect-dropdown >>> b2b-chip-component',
+    );
+    expect(chips.length).toBe(3);
   });
 
   it('should not increase in size when options are selected', async () => {


### PR DESCRIPTION
Not sure how to test this, but:
<img width="1380" height="142" alt="image" src="https://github.com/user-attachments/assets/7e01faa1-a1d4-430e-8a3d-7f19ca0df0c6" />

I'm not sure how to address this, but the components are inconsistent in their behavior
  * Either both should have default placeholder, or not (I prefer not to set it on default, because it doesn't make sense for German)
  * The default width is different too.

But how to change that? If either is setup for either component, that could lead to broken components for the users. 

Anyway, more issues:
* The example code doesn't work. the `options-list` is missing, for example.

```html
    <b2b-grid margin="0">
      <b2b-grid-row>
        <b2b-multiselect-dropdown> </b2b-multiselect-dropdown>
      </b2b-grid-row>
      <b2b-grid-row>
        <b2b-dropdown> </b2b-dropdown>
      </b2b-grid-row>
    </b2b-grid>

```