### PR TITLE
fix(input): fix broken nullish check

### DIFF
--- a/packages/core-components/src/components/input/input.tsx
+++ b/packages/core-components/src/components/input/input.tsx
@@ -136,9 +136,7 @@ export class InputComponent {
 
   private onInput = (ev: Event) => {
     const input = ev.target as HTMLInputElement | null;
-    if (input !== (undefined || null)) {
-      this.value = input.value || '';
-    }
+    this.value = input?.value || '';
     this.b2bInput.emit(input);
   };
 


### PR DESCRIPTION
The current check is broken:

````js
 if (input !== (undefined || null)) {
````

1. `(undefined || null)` => `false`
2. `(input !== false)` where `input: HTMLInputElement | null` => always `true`

